### PR TITLE
RSDEV-444: Upgrade rspace-external-auth to 2.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## 2.0.0 2026-04-29
+## 2.0.1 2026-04-29
 - Spring 6 / Hibernate 6 / Jakarta namespace migration
 - Switch to rspace-parent 3.0.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## 2.0.1 2026-04-29
+## 2.0.1 2026-07-28
 - Spring 6 / Hibernate 6 / Jakarta namespace migration
 - Switch to rspace-parent 3.0.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 2.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta namespace migration
+- Switch to rspace-parent 3.0.0
+
 ## 1.1.3
 - switch to parent-pom 2.1.1 (upgrades various dependencies)
 - bump google-api-client dependency (1.28.0 -> 1.35.2)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>3.0.0</version>
+    <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -46,17 +46,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-external-auth</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
 
   <parent>
     <artifactId>rspace-parent</artifactId>
@@ -31,7 +31,12 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.35.2</version>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client-gson</artifactId>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rspace-external-auth</artifactId>
-  <version>1.1.3</version>
+  <version>2.0.0</version>
 
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>2.1.1</version>
+    <version>3.0.0</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <artifactId>rspace-parent</artifactId>
     <groupId>com.github.rspace-os</groupId>
-    <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+    <version>3.0.0</version>
   </parent>
 
   <repositories>


### PR DESCRIPTION
Upgrade rspace-external-auth to 2.0.1 for Spring 6 / Jakarta migration (RSDEV-444).

Upgrades `google-api-client` 1.35.2 → 2.2.0 (Jakarta-compatible) and adds the `google-api-client-gson` module. Pom-only; no source changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
